### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    # Every day at 11:03 UTC.
+    - cron: '3 11 * * *'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -15,6 +18,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Xcode version
         run: sudo xcode-select -s /Applications/Xcode_13.0.app
-      - run: USE_BAZEL_VERSION=last_rc bazelisk test //...
       - run: bazelisk test //...
+      - run: USE_BAZEL_VERSION=rolling bazelisk test //...
       - run: USE_BAZEL_VERSION=last_green bazelisk test //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,19 +7,9 @@ rules_apple_linker_deps()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "bazel_skylib",
-    sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
-    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-)
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
-
-http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "a5f00fd89eff67291f6cd3efdc8fad30f4727e6ebb90718f3f05bbf3c3dd5ed7",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.33.0/rules_apple.0.33.0.tar.gz",
+    sha256 = "12865e5944f09d16364aa78050366aca9dc35a32a018fa35f5950238b08bf744",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.34.2/rules_apple.0.34.2.tar.gz",
 )
 
 load(
@@ -49,3 +39,7 @@ load(
 )
 
 apple_support_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()


### PR DESCRIPTION
- Run on a schedule to catch regressions in new bazel versions
- Replace last_rc with rolling, last_rc is close enough to the last
  release
- Remove skylib pinning and take it from other rules instead
- Fix rules_apple head incompatibility