### PR TITLE
Remove zld

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,6 @@ tasks:
     platform: macos
     build_targets:
       - '@rules_apple_linker//:lld'
-      - '@rules_apple_linker//:zld'
 
 bcr_test_module:
   module_path: ""

--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,4 @@
-load("@rules_apple_linker//:rules.bzl", "lld_override", "zld_override")
-
-zld_override(
-    name = "zld",
-    visibility = ["//visibility:public"],
-)
+load("@rules_apple_linker//:rules.bzl", "lld_override")
 
 lld_override(
     name = "lld",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,6 @@ non_module_deps = use_extension("//:deps.bzl", "linker_deps")
 use_repo(
     non_module_deps,
     "rules_apple_linker_lld",
-    "rules_apple_linker_zld",
 )
 
 apple_cc_configure = use_extension(

--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ The default linker for MachO binaries is maintained by Apple and
 generally referred to as `ld64` (even though the binary is still `ld`).
 Currently there are 2 primary alternatives:
 
-### zld
-
-[`zld`][zld] is a fork of `ld64` that optimizes performance. This means
-you likely get output that is very similar to what `ld64` produces.
-Unfortunately the base of `zld` naturally lags behind changes in `ld64`
-because Apple doesn't often push their changes. This means theoretically
-some features could be a bit behind what you get with Xcode's version.
-
 ### lld
 
 [`lld`][lld] is LLVM's linker. It is a completely separate
@@ -38,10 +30,9 @@ evolving quickly and is being used in production to link Chrome today.
 
 # Usage
 
-By default `rules_apple_linker` provides targets for `zld`
-(`@rules_apple_linker//:zld`) and `lld` (`@rules_apple_linker//:lld`)
-for you to use. To enable them add one of the rules to the `deps` of
-your targets:
+By default `rules_apple_linker` provides a target for `lld`
+(`@rules_apple_linker//:lld`) for you to use. To enable it add the
+target to the `deps` of your targets:
 
 ```bzl
 objc_library(
@@ -59,7 +50,7 @@ macro:
 
 ```bzl
 def my_custom_ios_unit_test(**kwargs):
-    deps = kwargs.pop("deps", []) + ["@rules_apple_linker//:zld"]
+    deps = kwargs.pop("deps", []) + ["@rules_apple_linker//:lld"]
     ios_unit_test(
         deps = deps,
         **kwargs
@@ -113,16 +104,16 @@ you want to use, you can pass the `linker` option when creating your own
 target:
 
 ```bzl
-load("@rules_apple_linker//:rules.bzl", "zld_override")
+load("@rules_apple_linker//:rules.bzl", "lld_override")
 
-zld_override(
-    name = "zld",
-    linker = "@zld//:my-newer-zld",
+lld_override(
+    name = "lld",
+    linker = "@lld//:my-newer-lld",
 )
 ```
 
-You can also use the `apple_linker_override` rule directly if
-you don't want `zld` or `lld` specific parameters.
+You can also use the `apple_linker_override` rule directly if you don't
+the `lld` specific parameters.
 
 ```bzl
 
@@ -150,4 +141,3 @@ like to use this with an older version please [open an issue][newissue]!
 [newissue]: https://github.com/keith/rules_apple_linker/issues/new
 [releases]: https://github.com/keith/rules_apple_linker/releases
 [rules_apple]: https://github.com/bazelbuild/rules_apple
-[zld]: https://github.com/michaeleisel/zld

--- a/deps.bzl
+++ b/deps.bzl
@@ -4,13 +4,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def rules_apple_linker_deps():
     http_archive(
-        name = "rules_apple_linker_zld",
-        build_file_content = 'filegroup(name = "zld_bin", srcs = ["zld"], visibility = ["//visibility:public"])',
-        sha256 = "b1897fbe2a2e27241d993d1ae55b5622efd9725139e8b9486b5d6e86cc291415",
-        url = "https://github.com/michaeleisel/zld/releases/download/1.3.7/zld.zip",
-    )
-
-    http_archive(
         name = "rules_apple_linker_lld",
         build_file_content = 'filegroup(name = "lld_bin", srcs = ["ld64.lld"], visibility = ["//visibility:public"])',
         sha256 = "b7f5c7aa573340eb85ca0895e2f689ee881eeb99c039a6d5eb2dafef53da4f28",

--- a/rules.bzl
+++ b/rules.bzl
@@ -87,23 +87,6 @@ apple_linker_override = rule(
     provides = [apple_common.Objc, CcInfo],
 )
 
-def _zld_override(ctx):
-    return _linker_override(ctx, ctx.attr.zld_linkopts)
-
-zld_override = rule(
-    implementation = _zld_override,
-    attrs = _attrs(
-        "@rules_apple_linker_zld//:zld_bin",
-        {
-            "zld_linkopts": attr.string_list(
-                mandatory = False,
-                doc = "The options to pass to zld, and not ld64 (see enable)",
-            ),
-        },
-    ),
-    provides = [apple_common.Objc, CcInfo],
-)
-
 def _lld_override(ctx):
     return _linker_override(ctx, ctx.attr.lld_linkopts)
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,5 +1,5 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
-load("@rules_apple_linker//:rules.bzl", "lld_override", "zld_override")
+load("@rules_apple_linker//:rules.bzl", "lld_override")
 load("@build_bazel_rules_apple//apple:macos.bzl", "macos_command_line_application")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load(":rules.bzl", "action_command_line_test")
@@ -16,11 +16,6 @@ lld_override(
     ld64_linkopts = ["-Wl,-add_empty_section,LD64,ENABLED"],
     linkopts = ["-Wl,-sectcreate,SHARED,LINKOPT,/dev/null"],
     lld_linkopts = ["-Wl,-sectcreate,LLD,ENABLED,/dev/null"],
-)
-
-zld_override(
-    name = "zld",
-    zld_linkopts = ["-Wl,-sectcreate,ZLD,ENABLED,/dev/null"],
 )
 
 cc_test(
@@ -46,12 +41,6 @@ cc_test(
     deps = [":lld"],
 )
 
-cc_test(
-    name = "zld_test",
-    srcs = ["main.c"],
-    deps = ["@rules_apple_linker//:zld"],
-)
-
 cc_library(
     name = "binary_lib",
     srcs = ["main.c"],
@@ -73,7 +62,7 @@ macos_command_line_application(
     minimum_os_version = "10.15",
     deps = [
         ":objc_binary_lib",
-        "@rules_apple_linker//:zld",
+        "@rules_apple_linker//:lld",
     ],
 )
 
@@ -82,8 +71,8 @@ ios_unit_test(
     minimum_os_version = "10.0",
     tags = ["manual"],
     deps = [
+        ":lld",
         ":objc_binary_lib",
-        ":zld",
     ],
 )
 
@@ -103,7 +92,7 @@ action_command_line_test(
 
 action_command_line_test(
     name = "command_line_tool_test",
-    expected_argv = ["--ld-path=external/$(BZLMOD)rules_apple_linker_zld/zld"],
+    expected_argv = ["--ld-path=external/$(BZLMOD)rules_apple_linker_lld/ld64.lld"],
     mnemonics = [
         "CppLink",
         "ObjcLink",
@@ -114,8 +103,8 @@ action_command_line_test(
 action_command_line_test(
     name = "ios_unit_test_test",
     expected_argv = [
-        "--ld-path=external/$(BZLMOD)rules_apple_linker_zld/zld",
-        "-Wl,-sectcreate,ZLD,ENABLED,/dev/null",
+        "--ld-path=external/$(BZLMOD)rules_apple_linker_lld/ld64.lld",
+        "-Wl,-sectcreate,LLD,ENABLED,/dev/null",
     ],
     mnemonics = [
         "CppLink",
@@ -147,18 +136,10 @@ action_command_line_test(
 )
 
 action_command_line_test(
-    name = "use_zld_test",
-    expected_argv = ["--ld-path=external/$(BZLMOD)rules_apple_linker_zld/zld"],
-    mnemonics = ["CppLink"],
-    target_under_test = ":zld_test",
-)
-
-action_command_line_test(
     name = "default_linker_test",
     mnemonics = ["CppLink"],
     not_expected_argv = [
         "--ld-path=external/$(BZLMOD)rules_apple_linker_lld/ld64.lld",
-        "--ld-path=external/$(BZLMOD)rules_apple_linker_zld/zld",
     ],
     target_under_test = ":default_test",
 )


### PR DESCRIPTION
This repo has been archived and zld doesn't support new features like
objc selector stubs. Performance of Xcode 15's linker has improved
enough that I don't think folks need this anymore. If you still want to
use zld with your own binaries you can use the apple_linker_override
rule.
