### PR TITLE
Add allow_files to linker

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -16,6 +16,7 @@ def _attrs(linker, extra_attrs):
     attrs = {
         "linker": attr.label(
             default = linker,
+            allow_files = True,
             executable = True,
             cfg = "exec",
             doc = "The linker to use",


### PR DESCRIPTION
I recently removed allow_single_file, but this should be allowed to use
a single file still, as well as multiple files.
