### PR TITLE
Bump bazel_skylib for rolling

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "apple_support", version = "1.15.1", dev_dependency = True, repo_name = "build_bazel_apple_support")
-bazel_dep(name = "bazel_skylib", version = "1.3.0", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.6.1", dev_dependency = True)
 bazel_dep(name = "rules_apple", version = "3.5.1", dev_dependency = True, repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_swift", version = "1.18.0", dev_dependency = True, repo_name = "build_bazel_rules_swift")
 


### PR DESCRIPTION
Seems like the newest rolling release resolves a newer version here so
it errored without bumping this. Doesn't matter since it's a dev dep
