### PR TITLE
Remove --check_direct_dependencies=error

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,3 @@
-common --check_direct_dependencies=error
 common --lockfile_mode=off
 
 # TODO: Remove once lld ignores this

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,9 +5,9 @@ module(
 )
 
 bazel_dep(name = "apple_support", version = "1.15.1", dev_dependency = True, repo_name = "build_bazel_apple_support")
-bazel_dep(name = "bazel_skylib", version = "1.6.1", dev_dependency = True)
-bazel_dep(name = "rules_apple", version = "3.5.1", dev_dependency = True, repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "1.18.0", dev_dependency = True, repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
+bazel_dep(name = "rules_apple", version = "3.13.0", dev_dependency = True, repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_swift", version = "2.2.1", dev_dependency = True, repo_name = "build_bazel_rules_swift")
 
 non_module_deps = use_extension("//:deps.bzl", "linker_deps")
 use_repo(


### PR DESCRIPTION
This makes testing with bazel @ HEAD harder, and using the lowest
versions supported is fine for this ruleset
